### PR TITLE
Fix number fomart validation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ export interface HTMLNumericElement
 export type NumericInputProps = Omit<TextFieldProps, 'onChange'> & {
   value?: number | string;
   onChange?(e: React.ChangeEvent<HTMLNumericElement>): void;
-
+  locale?: string;
   precision: number;
   thousandChar: string;
   decimalChar: string;
@@ -29,12 +29,13 @@ function verifyNumber(string: string) {
 }
 
 function NumericInput(props: NumericInputProps) {
-  const { value, precision, thousandChar, decimalChar, ...inputProps } = props;
+  const { value, precision, thousandChar, decimalChar, locale, ...inputProps } =
+    props;
   const defaultValue = value === null ? NaN : Number(value);
 
   const formatter = useMemo(
     () =>
-      new Intl.NumberFormat('pt-BR', {
+      new Intl.NumberFormat(locale || 'pt-BR', {
         minimumFractionDigits: precision,
         maximumFractionDigits: precision
       }),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ export interface HTMLNumericElement
 export type NumericInputProps = Omit<TextFieldProps, 'onChange'> & {
   value?: number | string;
   onChange?(e: React.ChangeEvent<HTMLNumericElement>): void;
-  locale?: string;
+
   precision: number;
   thousandChar: string;
   decimalChar: string;
@@ -36,7 +36,6 @@ function NumericInput(props: NumericInputProps) {
     precision,
     thousandChar,
     decimalChar,
-    locale,
     prefix,
     suffix,
     ...inputProps
@@ -45,7 +44,7 @@ function NumericInput(props: NumericInputProps) {
 
   const formatter = useMemo(
     () =>
-      new Intl.NumberFormat(locale || 'pt-BR', {
+      new Intl.NumberFormat('pt-BR', {
         minimumFractionDigits: precision,
         maximumFractionDigits: precision
       }),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import type { TextFieldProps } from '@mui/material';
-import { TextField } from '@mui/material';
+import { TextField, InputAdornment } from '@mui/material';
 import React, { useMemo } from 'react';
 
 export interface HTMLNumericElement
@@ -15,6 +15,8 @@ export type NumericInputProps = Omit<TextFieldProps, 'onChange'> & {
   precision: number;
   thousandChar: string;
   decimalChar: string;
+  prefix?: string;
+  suffix?: string;
 };
 
 function verifyNumber(string: string) {
@@ -29,8 +31,16 @@ function verifyNumber(string: string) {
 }
 
 function NumericInput(props: NumericInputProps) {
-  const { value, precision, thousandChar, decimalChar, locale, ...inputProps } =
-    props;
+  const {
+    value,
+    precision,
+    thousandChar,
+    decimalChar,
+    locale,
+    prefix,
+    suffix,
+    ...inputProps
+  } = props;
   const defaultValue = value === null ? NaN : Number(value);
 
   const formatter = useMemo(
@@ -137,6 +147,14 @@ function NumericInput(props: NumericInputProps) {
       onKeyDown={handleKeyDown}
       onChange={handleChange}
       value={inputValue}
+      InputProps={{
+        startAdornment: prefix && (
+          <InputAdornment position='start'>{prefix}</InputAdornment>
+        ),
+        endAdornment: suffix && (
+          <InputAdornment position='end'>{suffix}</InputAdornment>
+        )
+      }}
     />
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,7 +24,7 @@ function verifyNumber(string: string) {
 
   return {
     isNumber: !isNaN(Number(numericRepresentation)),
-    numberFomart: !isNaN(Number(numericRepresentation))
+    numberFormat: !isNaN(Number(numericRepresentation))
       ? Number(numericRepresentation)
       : null
   };
@@ -108,9 +108,9 @@ function NumericInput(props: NumericInputProps) {
       return props.onChange && props.onChange(newEvent);
     }
 
-    const { isNumber, numberFomart } = verifyNumber(numericRepresentation);
-    if (isNumber && numberFomart !== null) {
-      const withPrecision = numberFomart / 10 ** precision;
+    const { isNumber, numberFormat } = verifyNumber(numericRepresentation);
+    if (isNumber && numberFormat !== null) {
+      const withPrecision = numberFormat / 10 ** precision;
 
       const formattedNumber = format(withPrecision);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -99,7 +99,7 @@ function NumericInput(props: NumericInputProps) {
     }
 
     const { isNumber, numberFomart } = verifyNumber(numericRepresentation);
-    if (isNumber && numberFomart) {
+    if (isNumber && numberFomart !== null) {
       const withPrecision = numberFomart / 10 ** precision;
 
       const formattedNumber = format(withPrecision);


### PR DESCRIPTION
When the value of `numberFormat` is zero, it does not enter the if block.
Added Start and End Adornment.